### PR TITLE
Fix kernel driver headers and timer usage

### DIFF
--- a/ms912x.h
+++ b/ms912x.h
@@ -5,6 +5,10 @@
 #include <linux/mm_types.h>
 #include <linux/scatterlist.h>
 #include <linux/usb.h>
+#include <linux/workqueue.h> // FIX: struct work_struct
+#include <linux/timer.h> // FIX: struct timer_list
+#include <linux/completion.h> // FIX: struct completion
+#include <linux/slab.h> // FIX: kzalloc/vmalloc helpers
 
 #include <drm/drm_device.h>
 #include <drm/drm_framebuffer.h>

--- a/ms912x_drv.c
+++ b/ms912x_drv.c
@@ -6,8 +6,8 @@
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_damage_helper.h>
 #include <drm/drm_drv.h>
-#include <drm/drm_fb_helper.h>
-#include <drm/drm_fbdev_generic.h> // FIX: use generic fbdev helper
+#include <drm/drm_fb_helper.h> // FIX: ensure fb helper available
+// TODO: include <drm/drm_fbdev_generic.h> when available
 #include <drm/drm_file.h>
 #include <drm/drm_gem_atomic_helper.h>
 #include <drm/drm_gem_framebuffer_helper.h>
@@ -280,7 +280,8 @@ static int ms912x_usb_probe(struct usb_interface *interface,
 	if (ret)
 		goto err_free_request_1;
 
-        drm_fbdev_generic_setup(dev, 0); // FIX: use generic fbdev helper
+        // TODO: enable fbdev emulation with drm_fbdev_generic_setup()
+        // drm_fbdev_generic_setup(dev, 0);
 
 	return 0;
 

--- a/ms912x_registers.c
+++ b/ms912x_registers.c
@@ -1,5 +1,7 @@
 
 #include <uapi/linux/hid.h>
+#include <linux/slab.h> // FIX: kzalloc/kfree
+#include <linux/string.h> // FIX: memcpy/memset helpers
 
 #include "ms912x.h"
 

--- a/ms912x_transfer.c
+++ b/ms912x_transfer.c
@@ -2,6 +2,10 @@
 #include <linux/dma-buf.h>
 #include <linux/vmalloc.h>
 #include <linux/iosys-map.h> // FIX: required for iosys_map_memcpy_from
+#include <linux/workqueue.h> // FIX: workqueue support
+#include <linux/completion.h> // FIX: completion primitives
+#include <linux/timer.h> // FIX: for timer_list/from_timer/del_timer_sync
+#include <linux/slab.h> // FIX: kmalloc/kfree helpers
 
 #include <drm/drm_drv.h>
 #include <drm/drm_gem_framebuffer_helper.h>


### PR DESCRIPTION
## Summary
- include workqueue, timer, completion and slab headers for usb request handling
- drop unavailable drm_fbdev_generic header and comment out generic fbdev setup
- add slab/string headers in register access code for memory helpers

## Testing
- `make -j$(nproc)` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af0842cb348321a3e14a36b18de35d