### PR TITLE
Fix DRM driver for Linux 6.16 API

### DIFF
--- a/ms912x.h
+++ b/ms912x.h
@@ -18,7 +18,7 @@
 #include "ms912x_regs.h" // FIX: include register definitions
 #define DRIVER_NAME "ms912x"
 #define DRIVER_DESC "MacroSilicon USB to VGA/HDMI"
-#define DRIVER_DATE "20220101"
+/* DRIVER_DATE removed: legacy field no longer used in drm_driver */
 
 #define DRIVER_MAJOR 0
 #define DRIVER_MINOR 0

--- a/ms912x_drv.c
+++ b/ms912x_drv.c
@@ -54,19 +54,19 @@ ms912x_driver_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf)
 DEFINE_DRM_GEM_FOPS(ms912x_driver_fops);
 
 static const struct drm_driver driver = {
-	.driver_features = DRIVER_ATOMIC | DRIVER_GEM | DRIVER_MODESET,
+        .driver_features = DRIVER_ATOMIC | DRIVER_GEM | DRIVER_MODESET,
 
-	/* GEM hooks */
-	.fops = &ms912x_driver_fops,
-	DRM_GEM_SHMEM_DRIVER_OPS,
-	.gem_prime_import = ms912x_driver_gem_prime_import,
+        /* GEM hooks */
+        .fops = &ms912x_driver_fops,
+        DRM_GEM_SHMEM_DRIVER_OPS,
+        .gem_prime_import = ms912x_driver_gem_prime_import,
 
-	.name = DRIVER_NAME,
-	.desc = DRIVER_DESC,
-	.date = DRIVER_DATE,
-	.major = DRIVER_MAJOR,
-	.minor = DRIVER_MINOR,
-	.patchlevel = DRIVER_PATCHLEVEL,
+        .name = DRIVER_NAME,
+        .desc = DRIVER_DESC,
+        /* .date field removed in Linux 6.16+ */
+        .major = DRIVER_MAJOR,
+        .minor = DRIVER_MINOR,
+        .patchlevel = DRIVER_PATCHLEVEL,
 };
 
 static const struct drm_mode_config_funcs ms912x_mode_config_funcs = {

--- a/ms912x_transfer.c
+++ b/ms912x_transfer.c
@@ -5,6 +5,7 @@
 #include <linux/workqueue.h> // FIX: workqueue support
 #include <linux/completion.h> // FIX: completion primitives
 #include <linux/timer.h> // FIX: for timer_list/from_timer/del_timer_sync
+#include <linux/container_of.h> // Fallback for from_timer when unavailable
 #include <linux/slab.h> // FIX: kmalloc/kfree helpers
 
 #include <drm/drm_drv.h>
@@ -12,10 +13,15 @@
 
 #include "ms912x.h"
 
+/* In some kernel versions from_timer() is not available, provide a fallback */
+#ifndef from_timer
+#define from_timer(var, timer, field) container_of(timer, typeof(*var), field)
+#endif
+
 static void ms912x_request_timeout(struct timer_list *t)
 {
-	struct ms912x_usb_request *request = from_timer(request, t, timer);
-	usb_sg_cancel(&request->sgr);
+        struct ms912x_usb_request *request = from_timer(request, t, timer);
+        usb_sg_cancel(&request->sgr);
 }
 
 static void ms912x_request_work(struct work_struct *work)


### PR DESCRIPTION
## Summary
- add missing timer header and from_timer fallback
- drop removed `.date` field from `drm_driver`
- eliminate unused `DRIVER_DATE` macro

## Testing
- `make -j$(nproc) 2>&1 | head -n 200` *(fails: `/lib/modules/6.12.13/build: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68af09ceddc48321918a1dacb2c69efd