### PR TITLE
Fix timer/workqueue compat and add PyQt6 tray utility

### DIFF
--- a/ms912x.h
+++ b/ms912x.h
@@ -46,13 +46,14 @@ struct ms912x_device {
 	struct drm_connector connector;
 	struct drm_simple_display_pipe display_pipe;
 	
-	struct drm_rect update_rect;
+        struct drm_rect update_rect;
 
-	/* Double buffer to allow memcpy and transfer 
-	 * to happen in parallel
-	 */
-	int current_request;
-	struct ms912x_usb_request requests[2];
+        /* Double buffer to allow memcpy and transfer
+         * to happen in parallel
+         */
+        int current_request;
+        struct ms912x_usb_request requests[2];
+        struct workqueue_struct *wq; /* dedicated workqueue */
 };
 
 struct ms912x_request {

--- a/ms912x_compat.h
+++ b/ms912x_compat.h
@@ -3,19 +3,35 @@
 
 #include <linux/version.h>
 #include <linux/timer.h>
-#include <linux/workqueue.h> // flush_workqueue support
-#include <linux/rcupdate.h> // needed for synchronize_rcu
-#include <linux/jiffies.h> // jiffies helper for mod_timer
+#include <linux/workqueue.h> /* flush_workqueue support */
+#include <linux/rcupdate.h>  /* needed for synchronize_rcu */
+#include <linux/jiffies.h>   /* jiffies helper for mod_timer */
+#include <linux/container_of.h> /* container_of for from_timer */
 #include <drm/drm_device.h>
 
-/* REPLACEMENT: safe del_timer_sync analogue for older kernels */
-static inline int ms912x_del_timer_sync(struct timer_list *timer)
+/*
+ * REPLACEMENT: safe del_timer_sync analogue for older kernels.
+ * Takes an optional workqueue to avoid flushing the global queues.
+ */
+static inline int ms912x_del_timer_sync(struct timer_list *timer,
+                                       struct workqueue_struct *wq)
 {
-        int was_pending = mod_timer(timer, ~0UL); // COMPAT: emulate del_timer
-        flush_workqueue(system_long_wq);
+        int ret = del_timer(timer);
+        if (wq)
+                flush_workqueue(wq);
         synchronize_rcu();
-        return was_pending;
+        return ret;
 }
+
+/*
+ * Provide from_timer() for kernels where it is missing.  The macro
+ * behaves like the upstream helper and resolves the containing structure
+ * from the timer pointer.
+ */
+#ifndef from_timer
+#define from_timer(var, timer, field) \
+        container_of(timer, typeof(*var), field)
+#endif
 
 /* REPLACEMENT: wrapper for fbdev setup so driver builds without drm_fbdev_generic */
 #if __has_include(<drm/drm_fbdev_generic.h>)

--- a/ms912x_transfer.c
+++ b/ms912x_transfer.c
@@ -36,7 +36,7 @@ static void ms912x_request_work(struct work_struct *work)
 		    request->transfer_len, GFP_KERNEL);
 	mod_timer(&request->timer, jiffies + msecs_to_jiffies(5000));
         usb_sg_wait(sgr);
-        ms912x_del_timer_sync(&request->timer); // REPLACEMENT: safe timer delete
+        ms912x_del_timer_sync(&request->timer, ms912x->wq); /* safe timer delete */
         complete(&request->done);
 }
 
@@ -233,8 +233,8 @@ int ms912x_fb_send_rect(struct drm_framebuffer *fb, const struct iosys_map *map,
 		goto dev_exit;
 	}
 
-	current_request->transfer_len = width * 2 * drm_rect_height(rect) + 16;
-	queue_work(system_long_wq, &current_request->work);
+        current_request->transfer_len = width * 2 * drm_rect_height(rect) + 16;
+        queue_work(ms912x->wq, &current_request->work);
 	ms912x->current_request = 1 - ms912x->current_request;
 dev_exit:
         drm_dev_exit(idx); // FIX: paired with drm_dev_enter

--- a/ms912x_tray.py
+++ b/ms912x_tray.py
@@ -4,9 +4,9 @@
 import sys
 import subprocess
 
-from PyQt5.QtCore import QTimer
-from PyQt5.QtGui import QIcon, QPixmap, QColor, QPainter
-from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMenu
+from PyQt6.QtCore import QTimer
+from PyQt6.QtGui import QIcon, QPixmap, QColor, QPainter
+from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu
 
 DRIVER_NAME = "ms912x"
 
@@ -21,12 +21,11 @@ def driver_loaded() -> bool:
 
 
 def unload_driver() -> None:
-    """Attempt to unload the ms912x module using pkexec."""
+    """Attempt to unload the ms912x module."""
     try:
         subprocess.run(["pkexec", "rmmod", DRIVER_NAME], check=False)
     except FileNotFoundError:
-        # pkexec not available
-        pass
+        subprocess.run(["rmmod", DRIVER_NAME], check=False)
 
 
 class Tray:
@@ -34,10 +33,8 @@ class Tray:
         self.app = QApplication(sys.argv)
         self.tray = QSystemTrayIcon(self._create_icon(), self.app)
         menu = QMenu()
-        unload_action = menu.addAction("Выгрузить драйвер")
-        unload_action.triggered.connect(self.on_unload)
-        exit_action = menu.addAction("Выход")
-        exit_action.triggered.connect(self.app.quit)
+        exit_action = menu.addAction("Выйти")
+        exit_action.triggered.connect(self.on_exit)
         self.tray.setContextMenu(menu)
         self.tray.show()
         # Periodically check if the module is still loaded
@@ -55,7 +52,7 @@ class Tray:
         painter.end()
         return QIcon(pix)
 
-    def on_unload(self):
+    def on_exit(self):
         unload_driver()
         self.app.quit()
 
@@ -64,7 +61,7 @@ class Tray:
             self.app.quit()
 
     def run(self):
-        self.app.exec_()
+        self.app.exec()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide `from_timer` helper and use container-based macro
- replace `system_long_wq` use with device workqueue and timer compatibility wrapper
- port tray indicator to PyQt6 with exit menu that unloads module

## Testing
- `make modules` *(fails: /lib/modules/6.12.13/build: No such file or directory)*
- `python -m py_compile ms912x_tray.py`


------
https://chatgpt.com/codex/tasks/task_e_68af45c030048321a5e77d1b9db67fc1