### PR TITLE
Use timer_shutdown_sync for safe timer cleanup

### DIFF
--- a/ms912x_compat.h
+++ b/ms912x_compat.h
@@ -3,35 +3,24 @@
 
 #include <linux/version.h>
 #include <linux/timer.h>
-#include <linux/workqueue.h> /* flush_workqueue support */
-#include <linux/rcupdate.h>  /* needed for synchronize_rcu */
-#include <linux/jiffies.h>   /* jiffies helper for mod_timer */
-#include <linux/container_of.h> /* container_of for from_timer */
+#include <linux/container_of.h> /* container_of for helpers */
+#include <linux/workqueue.h>    /* still used elsewhere */
 #include <drm/drm_device.h>
 
 /*
- * REPLACEMENT: safe del_timer_sync analogue for older kernels.
- * Takes an optional workqueue to avoid flushing the global queues.
+ * Modern kernels (>=6.5) removed del_timer* helpers.  Provide a thin wrapper
+ * around timer_shutdown_sync() which guarantees the timer is cancelled and no
+ * callback is running.  The wrapper mirrors the previous ms912x_del_timer_sync
+ * semantics but does not return a value since timer_shutdown_sync() does not.
  */
-static inline int ms912x_del_timer_sync(struct timer_list *timer,
-                                       struct workqueue_struct *wq)
+static inline void ms912x_shutdown_timer(struct timer_list *timer)
 {
-        int ret = del_timer(timer);
-        if (wq)
-                flush_workqueue(wq);
-        synchronize_rcu();
-        return ret;
+        if (!timer)
+                return;
+
+        timer_shutdown_sync(timer);
 }
 
-/*
- * Provide from_timer() for kernels where it is missing.  The macro
- * behaves like the upstream helper and resolves the containing structure
- * from the timer pointer.
- */
-#ifndef from_timer
-#define from_timer(var, timer, field) \
-        container_of(timer, typeof(*var), field)
-#endif
 
 /* REPLACEMENT: wrapper for fbdev setup so driver builds without drm_fbdev_generic */
 #if __has_include(<drm/drm_fbdev_generic.h>)


### PR DESCRIPTION
## Summary
- replace deprecated timer helpers with ms912x_shutdown_timer wrapper
- stop USB request timers using ms912x_shutdown_timer and container_of

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af4884b9588321a114173902ff7ee3