### PR TITLE
Automate ms912x tray launch and update driver

### DIFF
--- a/99-ms912x.rules
+++ b/99-ms912x.rules
@@ -1,0 +1,5 @@
+# udev rule to launch ms912x tray utility when adapter is connected
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="345f", ATTR{idProduct}=="9133", \
+    TAG+="uaccess", ENV{SYSTEMD_USER_WANTS}+="ms912x_tray.service"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="345f", ATTR{idProduct}=="9132", \
+    TAG+="uaccess", ENV{SYSTEMD_USER_WANTS}+="ms912x_tray.service"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ You can load the module manually:
 sudo insmod ms912x.ko
 ```
 
+## Tray utility and automatic start
+
+A small PyQt6 tray helper (`ms912x_tray.py`) provides a red status icon and a
+context menu entry to unload the driver.  The utility starts automatically when
+an adapter is plugged in.
+
+To enable the automation copy the files to the appropriate system locations:
+
+```
+sudo install -m644 99-ms912x.rules /etc/udev/rules.d/
+sudo install -m755 ms912x_tray.py /usr/bin/
+sudo install -m644 ms912x_tray.service /usr/lib/systemd/user/
+systemctl --user daemon-reload
+```
+
+The udev rule triggers the `ms912x_tray.service` user unit which launches the
+tray application.  Right‑click the icon and choose *Выйти* to unload the module
+and close the utility.
+
 ## Testing
 
 Check kernel logs and connected outputs:

--- a/ms912x_drv.c
+++ b/ms912x_drv.c
@@ -399,4 +399,6 @@ static void __exit ms912x_exit(void)
 
 module_init(ms912x_init);
 module_exit(ms912x_exit);
+MODULE_DESCRIPTION("MS912X USB-HDMI video adapter driver");
+MODULE_AUTHOR("wdemon");
 MODULE_LICENSE("GPL");

--- a/ms912x_tray.service
+++ b/ms912x_tray.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MS912X tray utility
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ms912x_tray.py
+Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- Advertise ms912x driver via MODULE_DESCRIPTION and MODULE_AUTHOR
- Provide udev rule and systemd user service to auto-start PyQt6 tray utility
- Document tray installation and usage in README

## Testing
- `make` *(fails: `/lib/modules/6.12.13/build: No such file or directory`)*
- `python3 ms912x_tray.py` *(fails: `ImportError: libGL.so.1`)*


------
https://chatgpt.com/codex/tasks/task_e_68af5cab409483219b48953b1b1d6a67